### PR TITLE
fix(timedctl.py): activity shorthand

### DIFF
--- a/timedctl/timedctl.py
+++ b/timedctl/timedctl.py
@@ -435,7 +435,7 @@ def activity():
     pass  # pylint: disable=W0107
 
 
-@activity.command(aliases=["add", "s"])
+@activity.command(aliases=["add", "a"])
 @click.argument("comment")
 @click.option("--customer", default=None)
 @click.option("--project", default=None)


### PR DESCRIPTION
Fixes #19

Uses shorthand `a` instead of `s` for starting an activity.
