### PR TITLE
feat(oidc): implement device code flow with refresh tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ If this isn't the case you can see the default config options below:
 ```toml
 username = "<your username>"
 timed_url = "<timed url>"
-sso_url = "<sso url>"
-sso_realm = "<sso realm>"
+sso_discovery_url = "<sso url>"
 sso_client_id = "<client id>"
 ```
 

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -16,6 +16,7 @@ pkgbase = timedctl
 	depends = python-tomlkit>=0.11.8
 	depends = python-click-aliases>=1.0.1
 	depends = fzf>=0.42.0
+	depends = python-pyjwt>=2.8.0
 	provides = timedctl
 	conflicts = timedctl
 	source = git+https://github.com/adfinis/timedctl.git

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -7,7 +7,7 @@ url="https://github.com/adfinis/timedctl.git"
 license=("AGPL3")
 provides=("timedctl")
 conflicts=("timedctl")
-depends=("python>=3.10" "python-click>=8.1.3" "python-pyfzf>=0.3.1" "python-rich>=13.4.2" "python-libtimed>=0.6.4" "python-tomlkit>=0.11.8" "python-click-aliases>=1.0.1" "fzf>=0.42.0")
+depends=("python>=3.10" "python-click>=8.1.3" "python-pyfzf>=0.3.1" "python-rich>=13.4.2" "python-libtimed>=0.6.4" "python-tomlkit>=0.11.8" "python-click-aliases>=1.0.1" "fzf>=0.42.0" "python-pyjwt>=2.8.0")
 makedepends=("python-poetry" "python-installer" "git")
 source=("git+${url}")
 sha256sums=('SKIP')

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712608508,
-        "narHash": "sha256-vMZ5603yU0wxgyQeHJryOI+O61yrX2AHwY6LOFyV1gM=",
+        "lastModified": 1719690277,
+        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6",
+        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1708589824,
-        "narHash": "sha256-2GOiFTkvs5MtVF65sC78KNVxQSmsxtk0WmV1wJ9V2ck=",
+        "lastModified": 1719850884,
+        "narHash": "sha256-UU/lVTHFx0GpEkihoLJrMuM9DcuhZmNe3db45vshSyI=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "3c92540611f42d3fb2d0d084a6c694cd6544b609",
+        "rev": "42262f382c68afab1113ebd1911d0c93822d756e",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708335038,
-        "narHash": "sha256-ETLZNFBVCabo7lJrpjD6cAbnE11eDOjaQnznmg/6hAE=",
+        "lastModified": 1719749022,
+        "narHash": "sha256-ddPKHcqaKCIFSFc/cvxS14goUhCOAwsM1PbMr0ZtHMg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e504621290a1fd896631ddbc5e9c16f4366c9f65",
+        "rev": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
         "type": "github"
       },
       "original": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ rich = "^13.4.2"
 tomlkit = ">=0.11.8,<0.13.0"
 click-aliases = "^1.0.1"
 libtimed = "^0.6.4"
+keyring = ">=24.1,<26.0"
+requests = "^2.31.0"
+pyjwt = "^2.8.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/timedctl/timedctl.py
+++ b/timedctl/timedctl.py
@@ -151,7 +151,7 @@ class Timedctl:
             timeout=TIMEOUT,
         )
 
-        if device_code_response.status_code != requests.status_codes.codes.ok:
+        if device_code_response.status_code != requests.codes.ok:
             error_handler("ERR_GENERATING_DEVICE_CODE")
 
         device_code_data = device_code_response.json()
@@ -176,7 +176,7 @@ class Timedctl:
             )
             token_data = token_response.json()
 
-            if token_response.status_code == requests.status_codes.codes.ok:
+            if token_response.status_code == requests.codes.ok:
                 keyring.set_password(
                     "system",
                     "timedctl_token_" + client_id + "_access",
@@ -212,7 +212,7 @@ class Timedctl:
         )
         token_data = token_response.json()
 
-        if token_response.status_code != requests.status_codes.codes.ok:
+        if token_response.status_code != requests.codes.ok:
             return self.login()
 
         keyring.set_password(

--- a/timedctl/timedctl.py
+++ b/timedctl/timedctl.py
@@ -3,14 +3,17 @@
 
 import os
 import re
+import time
+import webbrowser
 from datetime import datetime, timedelta
 
 import click
+import jwt
+import keyring
 import pyfzf
 import requests
 import tomllib
 from libtimed import TimedAPIClient
-from libtimed.oidc import OIDCClient
 from rich import print
 from rich.table import Table
 from tomlkit import dump
@@ -23,6 +26,8 @@ from timedctl.helpers import (
     time_picker,
 )
 
+TIMEOUT = 30
+
 
 class Timedctl:
     def __init__(self):
@@ -33,8 +38,7 @@ class Timedctl:
         cfg = {
             "username": "test",
             "timed_url": "https://timed.example.com",
-            "sso_url": "https://sso.example.com",
-            "sso_realm": "example",
+            "sso_discovery_url": "https://sso.example.com/realms/example",
             "sso_client_id": "timedctl",
         }
 
@@ -63,6 +67,22 @@ class Timedctl:
         else:
             with open(config_file, "rb") as file:
                 user_config = tomllib.load(file)
+
+            # Migration from sso_url & sso_realm to sso_discovery_url
+            if (
+                "sso_discovery_url" not in user_config
+                and "sso_url" in user_config
+                and "sso_realm" in user_config
+            ):
+                user_config["sso_discovery_url"] = (
+                    user_config["sso_url"] + "/realms/" + user_config["sso_realm"]
+                )
+                del user_config["sso_url"]
+                del user_config["sso_realm"]
+
+                with open(config_file, "w", encoding="utf-8") as file:
+                    dump(user_config, file)
+
             for key in user_config:
                 cfg[key] = user_config[key]
         self.config = cfg
@@ -72,24 +92,135 @@ class Timedctl:
         # initialize libtimed
         url = self.config.get("timed_url")
         api_namespace = "api/v1"
+        client_id = self.config["sso_client_id"]
 
-        # Auth stuff
+        access_token = keyring.get_password(
+            "system", "timedctl_token_" + client_id + "_access"
+        )
+        decode_options = {"verify_signature": False, "verify_exp": "verify_signature"}
+        try:
+            # Check if access_token is valid
+            jwt.decode(access_token, leeway=-30, options=decode_options)
+
+        except (jwt.exceptions.ExpiredSignatureError, jwt.exceptions.DecodeError):
+            # Access token expired or missing
+            refresh_token = keyring.get_password(
+                "system", "timedctl_token_" + client_id + "_refresh"
+            )
+            try:
+                jwt.decode(refresh_token, leeway=-10, options=decode_options)
+                access_token = self.refresh_token(refresh_token)
+
+            except (jwt.exceptions.ExpiredSignatureError, jwt.exceptions.DecodeError):
+                # Refresh token expired or missing
+                if no_renew_token:
+                    error_handler("ERR_TOKEN_MISSING_OR_EXPIRED")
+
+                access_token = self.login()
+
+        self.timed = TimedAPIClient(access_token, url, api_namespace)
+
+    def get_openid_configuration(self):
+        """Return the OpenID configuration."""
+        sso_discovery_url = self.config.get("sso_discovery_url")
+
+        # Retrieve OpenID configuration
+        openid_configuration = requests.get(
+            f"{sso_discovery_url}/.well-known/openid-configuration", timeout=TIMEOUT
+        ).json()
+        if "error" in openid_configuration:
+            error_handler("ERR_COULD_NOT_GET_OPENID_CONFIGURATION")
+
+        return openid_configuration
+
+    def login(self):
+        """Authenticates using device code."""
         client_id = self.config.get("sso_client_id")
-        sso_url = self.config.get("sso_url")
-        sso_realm = self.config.get("sso_realm")
-        auth_path = "timedctl/auth"
-        self.oidc_client = OIDCClient(client_id, sso_url, sso_realm, auth_path)
+        openid_configuration = self.get_openid_configuration()
 
-        # don't auto-refresh the token if asked
-        if no_renew_token:
-            token = self.oidc_client.keyring_get()
-            if not token:
-                error_handler("ERR_NO_TOKEN")
-            if not self.oidc_client.check_expired(token):
-                error_handler("ERR_TOKEN_EXPIRED")
+        if (
+            "urn:ietf:params:oauth:grant-type:device_code"
+            not in openid_configuration["grant_types_supported"]
+        ):
+            error_handler("ERR_SSO_DOES_NOT_SUPPORT_DEVICE_CODE")
 
-        token = self.oidc_client.authorize()
-        self.timed = TimedAPIClient(token, url, api_namespace)
+        device_code_payload = {"client_id": client_id, "scope": "openid"}
+        device_code_response = requests.post(
+            openid_configuration["device_authorization_endpoint"],
+            data=device_code_payload,
+            timeout=TIMEOUT,
+        )
+
+        if device_code_response.status_code != requests.status_codes.codes.ok:
+            error_handler("ERR_GENERATING_DEVICE_CODE")
+
+        device_code_data = device_code_response.json()
+        print(
+            "A web browser was opened at {}. Please continue the login in the web browser.".format(
+                device_code_data["verification_uri_complete"]
+            )
+        )
+        webbrowser.open_new(device_code_data["verification_uri_complete"])
+
+        token_payload = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code_data["device_code"],
+            "client_id": client_id,
+        }
+
+        while True:
+            token_response = requests.post(
+                openid_configuration["token_endpoint"],
+                data=token_payload,
+                timeout=TIMEOUT,
+            )
+            token_data = token_response.json()
+
+            if token_response.status_code == requests.status_codes.codes.ok:
+                keyring.set_password(
+                    "system",
+                    "timedctl_token_" + client_id + "_access",
+                    token_data["access_token"],
+                )
+                keyring.set_password(
+                    "system",
+                    "timedctl_token_" + client_id + "_refresh",
+                    token_data["refresh_token"],
+                )
+                return token_data["access_token"]
+            elif token_data["error"] not in ("authorization_pending", "slow_down"):
+                print(token_data["error_description"])
+                error_handler("ERR_AUTHORIZATION_FAILED")
+            else:
+                time.sleep(device_code_data["interval"])
+
+    def refresh_token(self, token):
+        """Refresh token."""
+        client_id = self.config.get("sso_client_id")
+        openid_configuration = self.get_openid_configuration()
+
+        if "refresh_token" not in openid_configuration["grant_types_supported"]:
+            error_handler("ERR_SSO_DOES_NOT_SUPPORT_REFRESH")
+
+        token_payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": token,
+            "client_id": client_id,
+        }
+        token_response = requests.post(
+            openid_configuration["token_endpoint"], data=token_payload, timeout=TIMEOUT
+        )
+        token_data = token_response.json()
+
+        if token_response.status_code != requests.status_codes.codes.ok:
+            return self.login()
+
+        keyring.set_password(
+            "system",
+            "timedctl_token_" + client_id + "_access",
+            token_data["access_token"],
+        )
+        return token_data["access_token"]
 
     def force_renew(self):
         """Force a token renewal."""

--- a/timedctl/timedctl.py
+++ b/timedctl/timedctl.py
@@ -109,7 +109,7 @@ class Timedctl:
             )
             try:
                 jwt.decode(refresh_token, leeway=-10, options=decode_options)
-                access_token = self.refresh_token(refresh_token)
+                access_token = self.refresh_token(refresh_token, no_renew_token)
 
             except (jwt.exceptions.ExpiredSignatureError, jwt.exceptions.DecodeError):
                 # Refresh token expired or missing
@@ -194,7 +194,7 @@ class Timedctl:
             else:
                 time.sleep(device_code_data["interval"])
 
-    def refresh_token(self, token):
+    def refresh_token(self, token, no_renew_token=False):
         """Refresh token."""
         client_id = self.config.get("sso_client_id")
         openid_configuration = self.get_openid_configuration()
@@ -213,6 +213,9 @@ class Timedctl:
         token_data = token_response.json()
 
         if token_response.status_code != requests.codes.ok:
+            if no_renew_token:
+                error_handler("ERR_REFRESHING_TOKEN")
+
             return self.login()
 
         keyring.set_password(


### PR DESCRIPTION
Implemented oidc using the device code flow and made it generic oidc, instead of Keycloak dependent.

Config changed a bit, but migration is in place and doesn't need user interaction:
```
{
    "username": "test",
    "timed_url": "https://timed.example.com",
    "sso_url": "https://sso.example.com",
    "sso_realm": "example",
    "sso_client_id": "timedctl",
}
```
to:
```
{
    "username": "test",
    "timed_url": "https://timed.example.com",
    "sso_discovery_url": "https://sso.example.com/realms/example",
    "sso_client_id": "timedctl",
}
```